### PR TITLE
cache 2/3 atlases

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -52,6 +52,17 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install setuptools tox tox-gh-actions
 
+
+      # cache two largest out of the three atlases needed by the tests
+      - name: Cache Atlases
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.brainglobe/allen_mouse_100um*
+            ~/.brainglobe/osten_mouse_100um*
+          key: cached-atlases
+          enableCrossOsArchive: true
+
       # this runs the platform-specific tests declared in tox.ini
       - name: Test with tox
         uses: GabrielBB/xvfb-action@v1


### PR DESCRIPTION
## Description

This PR adds caching of atlases to GH actions.
We only cache the two larger test atlases, to ensure that the tests check that downloading is triggered by widget.

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Faster CI tests!

**What does this PR do?**
See description

## References

Closes #10 

## How has this PR been tested?
![image](https://github.com/brainglobe/brainglobe-napari/assets/10500965/8345eeca-79ac-4957-a2c2-b8e85a0f8544)

Manual running of same GH action twice. [1st run](https://github.com/brainglobe/brainglobe-napari/actions/runs/5093253945) took ~12 minutes, 2nd run finds cache (screenshot above) and takes ~10 minutes. (Was hoping for a stronger improvement but hey-ho!?)

## Is this a breaking change?

Nope.

## Does this PR require an update to the documentation?

Don't think so, purpose of caching step documented in comment in workflow file.

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
