### PR TITLE
Encapsulate atlas representation

### DIFF
--- a/src/brainglobe_napari/atlas_viewer_widget.py
+++ b/src/brainglobe_napari/atlas_viewer_widget.py
@@ -12,7 +12,6 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     pass
 
-
 from bg_atlasapi import BrainGlobeAtlas
 from bg_atlasapi.list_atlases import get_all_atlases_lastversions
 from napari.viewer import Viewer
@@ -25,6 +24,10 @@ from qtpy.QtWidgets import (
     QTextEdit,
     QVBoxLayout,
     QWidget,
+)
+
+from brainglobe_napari.napari_atlas_representation import (
+    NapariAtlasRepresentation,
 )
 
 
@@ -98,18 +101,19 @@ class AtlasViewerWidget(QWidget):
         self._selected_atlas_name = None
 
         # set up add button
-        self.add_annotation_button = QPushButton()
-        self.add_annotation_button.setText("View annotations image")
+        self.show_in_viewer = QPushButton()
+        self.show_in_viewer.setText("Show in viewer")
 
-        def _on_add_annotations_clicked():
+        def _on_show_in_viewer_clicked():
             """Adds annotations as labels layer to the viewer."""
             if self._selected_atlas_row is not None:
                 selected_atlas = BrainGlobeAtlas(self._selected_atlas_name)
-                napari_viewer.add_labels(
-                    selected_atlas.annotation, name=self._selected_atlas_name
+                selected_atlas_representation = NapariAtlasRepresentation(
+                    selected_atlas
                 )
+                selected_atlas_representation.add_to_viewer(self._viewer)
 
-        self.add_annotation_button.clicked.connect(_on_add_annotations_clicked)
+        self.show_in_viewer.clicked.connect(_on_show_in_viewer_clicked)
 
         # set up atlas info display
         self.atlas_info = QTextEdit(self)
@@ -137,5 +141,5 @@ class AtlasViewerWidget(QWidget):
 
         # add sub-widgets to top-level widget
         self.layout().addWidget(self.atlas_table_view)
-        self.layout().addWidget(self.add_annotation_button)
+        self.layout().addWidget(self.show_in_viewer)
         self.layout().addWidget(self.atlas_info)

--- a/src/brainglobe_napari/atlas_viewer_widget.py
+++ b/src/brainglobe_napari/atlas_viewer_widget.py
@@ -101,10 +101,10 @@ class AtlasViewerWidget(QWidget):
         self._selected_atlas_name = None
 
         # set up add button
-        self.show_in_viewer = QPushButton()
-        self.show_in_viewer.setText("Show in viewer")
+        self.add_to_viewer = QPushButton()
+        self.add_to_viewer.setText("Add to viewer")
 
-        def _on_show_in_viewer_clicked():
+        def _on_add_to_viewer_clicked():
             """Adds annotations as labels layer to the viewer."""
             if self._selected_atlas_row is not None:
                 selected_atlas = BrainGlobeAtlas(self._selected_atlas_name)
@@ -113,7 +113,7 @@ class AtlasViewerWidget(QWidget):
                 )
                 selected_atlas_representation.add_to_viewer(self._viewer)
 
-        self.show_in_viewer.clicked.connect(_on_show_in_viewer_clicked)
+        self.add_to_viewer.clicked.connect(_on_add_to_viewer_clicked)
 
         # set up atlas info display
         self.atlas_info = QTextEdit(self)
@@ -141,5 +141,5 @@ class AtlasViewerWidget(QWidget):
 
         # add sub-widgets to top-level widget
         self.layout().addWidget(self.atlas_table_view)
-        self.layout().addWidget(self.show_in_viewer)
+        self.layout().addWidget(self.add_to_viewer)
         self.layout().addWidget(self.atlas_info)

--- a/src/brainglobe_napari/napari_atlas_representation.py
+++ b/src/brainglobe_napari/napari_atlas_representation.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass
+
+from bg_atlasapi import BrainGlobeAtlas
+from napari.viewer import Viewer
+
+
+@dataclass
+class NapariAtlasRepresentation:
+    """Representation of a BG atlas as napari layers"""
+
+    bg_atlas: BrainGlobeAtlas
+
+    def add_to_viewer(self, viewer: Viewer):
+        """Adds the annotation and reference images to a viewer.
+
+        The annotation image is on top, and visible,
+        while the reference image is below it and invisible.
+        """
+        viewer.add_image(
+            self.bg_atlas.reference,
+            name=f"{self.bg_atlas.atlas_name}_reference",
+            visible=False,
+        )
+        viewer.add_labels(
+            self.bg_atlas.annotation,
+            name=f"{self.bg_atlas.atlas_name}_annotation",
+        )

--- a/src/brainglobe_napari/tests/test_atlas_viewer_widget.py
+++ b/src/brainglobe_napari/tests/test_atlas_viewer_widget.py
@@ -30,7 +30,7 @@ def test_show_in_viewer_button(make_atlas_viewer, row, expected_atlas_name):
     viewer, atlas_viewer = make_atlas_viewer
 
     atlas_viewer.atlas_table_view.selectRow(row)
-    atlas_viewer.show_in_viewer.click()
+    atlas_viewer.add_to_viewer.click()
     assert len(viewer.layers) == 2
     assert viewer.layers[1].name == f"{expected_atlas_name}_annotation"
     assert viewer.layers[0].name == f"{expected_atlas_name}_reference"
@@ -41,5 +41,5 @@ def test_show_in_viewer_button_no_selection(make_atlas_viewer):
     a selection does not add a layer."""
     viewer, atlas_viewer = make_atlas_viewer
 
-    atlas_viewer.show_in_viewer.click()
+    atlas_viewer.add_to_viewer.click()
     assert len(viewer.layers) == 0

--- a/src/brainglobe_napari/tests/test_atlas_viewer_widget.py
+++ b/src/brainglobe_napari/tests/test_atlas_viewer_widget.py
@@ -24,21 +24,22 @@ def make_atlas_viewer(make_napari_viewer) -> Tuple[Viewer, AtlasViewerWidget]:
         (14, "osten_mouse_100um"),
     ],
 )
-def test_add_annotation_button(make_atlas_viewer, row, expected_atlas_name):
+def test_show_in_viewer_button(make_atlas_viewer, row, expected_atlas_name):
     """Check for a few low-res atlas selections that clicking the
-    "Add Annotation" button adds a layer with the expected name."""
+    "Show in Viewer" button adds a layer with the expected name."""
     viewer, atlas_viewer = make_atlas_viewer
 
     atlas_viewer.atlas_table_view.selectRow(row)
-    atlas_viewer.add_annotation_button.click()
-    assert len(viewer.layers) == 1
-    assert viewer.layers[0].name == expected_atlas_name
+    atlas_viewer.show_in_viewer.click()
+    assert len(viewer.layers) == 2
+    assert viewer.layers[1].name == f"{expected_atlas_name}_annotation"
+    assert viewer.layers[0].name == f"{expected_atlas_name}_reference"
 
 
-def test_add_annotations_button_no_selection(make_atlas_viewer):
-    """Check that clicking "Add Annotation" button without
+def test_show_in_viewer_button_no_selection(make_atlas_viewer):
+    """Check that clicking "Show in Viewer" button without
     a selection does not add a layer."""
     viewer, atlas_viewer = make_atlas_viewer
 
-    atlas_viewer.add_annotation_button.click()
+    atlas_viewer.show_in_viewer.click()
     assert len(viewer.layers) == 0

--- a/src/brainglobe_napari/tests/test_napari_atlas_representation.py
+++ b/src/brainglobe_napari/tests/test_napari_atlas_representation.py
@@ -1,0 +1,17 @@
+from bg_atlasapi import BrainGlobeAtlas
+
+from brainglobe_napari.napari_atlas_representation import (
+    NapariAtlasRepresentation,
+)
+
+
+def test_add_to_viewer(make_napari_viewer):
+    viewer = make_napari_viewer()
+    atlas_name = "allen_mouse_100um"
+    atlas_representation = NapariAtlasRepresentation(
+        BrainGlobeAtlas(atlas_name=atlas_name)
+    )
+    atlas_representation.add_to_viewer(viewer=viewer)
+    assert len(viewer.layers) == 2
+    assert viewer.layers[1].name == f"{atlas_name}_annotation"
+    assert viewer.layers[0].name == f"{atlas_name}_reference"


### PR DESCRIPTION
## Description
This PR encapsulates how BG atlases are represented in napari into its own class.

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
It seems useful to make #3 independent to everything else here (because this issue depends on changes to napari), and I think this will help.

## References

A step towards #3 and towards #1 .

## How has this PR been tested?

Tests pass locally. New test added for `NapariAtlasRepresentation`.

## Is this a breaking change?

Kind of. (Button now adds both reference and annotation image as napari layers)

## Does this PR require an update to the documentation?

- all new functionality has docstrings.
- seems to early to fully write up high-level user and dev docs.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
