### PR TITLE
Cache atlases

### DIFF
--- a/src/brainglobe_napari/atlas_viewer_widget.py
+++ b/src/brainglobe_napari/atlas_viewer_widget.py
@@ -99,6 +99,7 @@ class AtlasViewerWidget(QWidget):
 
         self._selected_atlas_row = None
         self._selected_atlas_name = None
+        self._cached_atlases = {}
 
         # set up add button
         self.add_to_viewer = QPushButton()
@@ -107,7 +108,10 @@ class AtlasViewerWidget(QWidget):
         def _on_add_to_viewer_clicked():
             """Adds annotations as labels layer to the viewer."""
             if self._selected_atlas_row is not None:
-                selected_atlas = BrainGlobeAtlas(self._selected_atlas_name)
+                # atlas was necessarily cached on change of selection
+                selected_atlas = self._cached_atlases[
+                    self._selected_atlas_name
+                ]
                 selected_atlas_representation = NapariAtlasRepresentation(
                     selected_atlas
                 )
@@ -130,7 +134,15 @@ class AtlasViewerWidget(QWidget):
                 self._selected_atlas_name = self._model.data(
                     self._model.index(self._selected_atlas_row, 0)
                 )
-                selected_atlas = BrainGlobeAtlas(self._selected_atlas_name)
+                if self._selected_atlas_name in self._cached_atlases:
+                    selected_atlas = self._cached_atlases[
+                        self._selected_atlas_name
+                    ]
+                else:
+                    selected_atlas = BrainGlobeAtlas(self._selected_atlas_name)
+                    self._cached_atlases[
+                        self._selected_atlas_name
+                    ] = selected_atlas
                 self.atlas_info.setText(str(selected_atlas))
             else:
                 self.atlas_info.setText("")

--- a/src/brainglobe_napari/atlas_viewer_widget.py
+++ b/src/brainglobe_napari/atlas_viewer_widget.py
@@ -69,6 +69,8 @@ class AtlasViewerWidget(QWidget):
     and other widgets to visualise atlases in napari.
 
     Internal state depends on currently selected row in the table view.
+
+    Previously selected atlases are cached to avoid slow re-instantiation.
     """
 
     def __init__(self, napari_viewer: Viewer):

--- a/src/brainglobe_napari/tests/test_atlas_viewer_widget.py
+++ b/src/brainglobe_napari/tests/test_atlas_viewer_widget.py
@@ -1,3 +1,4 @@
+import time
 from typing import Tuple
 
 import pytest
@@ -43,3 +44,23 @@ def test_show_in_viewer_button_no_selection(make_atlas_viewer):
 
     atlas_viewer.add_to_viewer.click()
     assert len(viewer.layers) == 0
+
+
+def test_atlas_caching(make_atlas_viewer):
+    viewer, atlas_viewer = make_atlas_viewer
+    start_no_cache = time.time()
+    # select example mouse atlas - this will require instantiation (but not download)
+    atlas_viewer.atlas_table_view.selectRow(0)  
+    end_no_cache = time.time()
+
+    atlas_viewer.atlas_table_view.selectRow(4)  # select another atlas
+
+    start_with_cache = time.time()
+    # select example mouse atlas again - this atlas should be cached now.
+    atlas_viewer.atlas_table_view.selectRow(0)
+    end_with_cache = time.time()
+
+    elapsed_no_cache = end_no_cache - start_no_cache
+    elapsed_with_cache = end_with_cache - start_with_cache
+
+    assert elapsed_with_cache < elapsed_no_cache


### PR DESCRIPTION
## Description

The PR adds caching functionality to the Atlas Viewer widget, avoid re-instantiation of `BrainGlobeAtlas` classes.

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Switching between atlas rows is laggy.

## References

Closes #13 

## How has this PR been tested?

New test added for new functionality. Tests pass locally.

## Is this a breaking change?

Nope.

## Does this PR require an update to the documentation?

Caching is now mentioned in widget docstring.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
