### PR TITLE
add auto-used fixture to mock user data during testing

### DIFF
--- a/src/brainglobe_napari/tests/conftest.py
+++ b/src/brainglobe_napari/tests/conftest.py
@@ -20,9 +20,9 @@ def mock_brainglobe_user_folders(monkeypatch):
     """
     if not os.getenv("GITHUB_ACTIONS"):
         home_path = Path.home()  # actual home path
-        mock_home_path = Path(home_path / ".brainglobe-tests")
-        if not Path.exists(mock_home_path):
-            Path.mkdir(mock_home_path)
+        mock_home_path = home_path / ".brainglobe-tests"
+        if not mock_home_path.exists():
+            mock_home_path.mkdir()
 
         def mock_home():
             return mock_home_path

--- a/src/brainglobe_napari/tests/conftest.py
+++ b/src/brainglobe_napari/tests/conftest.py
@@ -1,0 +1,48 @@
+import os
+from pathlib import Path
+
+import pytest
+from bg_atlasapi import config
+
+
+@pytest.fixture(autouse=True)
+def mock_brainglobe_user_folders(monkeypatch):
+    """Ensures user config and data is mocked during all local testing.
+
+    User config and data need mocking to avoid interfering with user data.
+    Mocking is achieved by turning user data folders used in tests into
+    subfolders of a new ~/.brainglobe-tests folder instead of ~/.
+
+    It is not sufficient to mock the home path in the tests, as this
+    will leave later imports in other modules unaffected.
+
+    GH actions workflow will test with default user folders.
+    """
+    if not os.getenv("GITHUB_ACTIONS"):
+        home_path = Path.home()  # actual home path
+        mock_home_path = Path(home_path / ".brainglobe-tests")
+        if not Path.exists(mock_home_path):
+            Path.mkdir(mock_home_path)
+
+        def mock_home():
+            return mock_home_path
+
+        monkeypatch.setattr(Path, "home", mock_home)
+
+        # also mock global variables of config.py
+        monkeypatch.setattr(
+            config, "DEFAULT_PATH", mock_home_path / ".brainglobe"
+        )
+        monkeypatch.setattr(
+            config, "CONFIG_DIR", mock_home_path / ".config" / "brainglobe"
+        )
+        monkeypatch.setattr(
+            config, "CONFIG_PATH", config.CONFIG_DIR / config.CONFIG_FILENAME
+        )
+        mock_default_dirs = {
+            "default_dirs": {
+                "brainglobe_dir": mock_home_path / ".brainglobe",
+                "interm_download_dir": mock_home_path / ".brainglobe",
+            }
+        }
+        monkeypatch.setattr(config, "TEMPLATE_CONF_DICT", mock_default_dirs)


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Running the tests should not interfere with local user data.

**What does this PR do?**
Adds a fixture that is automatically used by all (local) tests that ensures that code using the local user folders (`~/.brainglobe` and `~/.config/brainglobe`) is redirected to folders of the same name, but located under `~/.brainglobe-tests/`. GH actions will run with the default user folders.

## References
Closes #23 

## How has this PR been tested?

Extensive manual testing locally by @alessandrofelder on an Ubuntu desktop.

## Is this a breaking change?
Nope.

## Does this PR require an update to the documentation?
Yes, this should be added to the new website as part of the developer documentation. Made [a note](https://github.com/brainglobe/new-website/issues/8#issuecomment-1587451379) of this.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
