### PR TITLE
Add root mesh

### DIFF
--- a/src/brainglobe_napari/atlas_viewer_widget.py
+++ b/src/brainglobe_napari/atlas_viewer_widget.py
@@ -137,9 +137,9 @@ class AtlasViewerWidget(QWidget):
                 if self._selected_atlas_name in get_downloaded_atlases():
                     selected_atlas = BrainGlobeAtlas(self._selected_atlas_name)
                     selected_atlas_representation = NapariAtlasRepresentation(
-                        selected_atlas
+                        selected_atlas, self._viewer
                     )
-                    selected_atlas_representation.add_to_viewer(self._viewer)
+                    selected_atlas_representation.add_to_viewer()
                 else:
                     show_info("Please download this atlas first.")
 

--- a/src/brainglobe_napari/napari_atlas_representation.py
+++ b/src/brainglobe_napari/napari_atlas_representation.py
@@ -11,6 +11,8 @@ class NapariAtlasRepresentation:
 
     bg_atlas: BrainGlobeAtlas
     viewer: Viewer
+    mesh_opacity: float = 0.4
+    mesh_blending: str = "translucent_no_depth"
 
     def add_to_viewer(self):
         """Adds the annotation and reference images,
@@ -44,6 +46,6 @@ class NapariAtlasRepresentation:
         self.viewer.add_surface(
             (points, cells),
             name=name,
-            opacity=0.4,
-            blending="translucent_no_depth",
+            opacity=self.mesh_opacity,
+            blending=self.mesh_blending,
         )

--- a/src/brainglobe_napari/napari_atlas_representation.py
+++ b/src/brainglobe_napari/napari_atlas_representation.py
@@ -37,7 +37,9 @@ class NapariAtlasRepresentation:
         mesh: the mesh to add
         name: name for the surface layer
         """
-        points = mesh.points / self.bg_atlas.resolution
+        points = mesh.points
+        for i in range(3):
+            points[:, i] /= self.bg_atlas.resolution[i]
         cells = mesh.cells[0].data
         self.viewer.add_surface(
             (points, cells),

--- a/src/brainglobe_napari/napari_atlas_representation.py
+++ b/src/brainglobe_napari/napari_atlas_representation.py
@@ -37,13 +37,7 @@ class NapariAtlasRepresentation:
         mesh: the mesh to add
         name: name for the surface layer
         """
-        # assume local_full_name is a string
-        # structured like "allen_mouse_100um_v1.2"
-        # so we can split by '_' and 'um' to find scale.
-        scale_um = float(
-            self.bg_atlas.local_full_name.split("_")[-2].split("um")[0]
-        )
-        points = mesh.points / scale_um
+        points = mesh.points / self.bg_atlas.resolution
         cells = mesh.cells[0].data
         self.viewer.add_surface(
             (points, cells),

--- a/src/brainglobe_napari/napari_atlas_representation.py
+++ b/src/brainglobe_napari/napari_atlas_representation.py
@@ -20,11 +20,13 @@ class NapariAtlasRepresentation:
         """
         self.viewer.add_image(
             self.bg_atlas.reference,
+            scale=self.bg_atlas.resolution,
             name=f"{self.bg_atlas.atlas_name}_reference",
             visible=False,
         )
         self.viewer.add_labels(
             self.bg_atlas.annotation,
+            scale=self.bg_atlas.resolution,
             name=f"{self.bg_atlas.atlas_name}_annotation",
         )
 
@@ -38,8 +40,6 @@ class NapariAtlasRepresentation:
         name: name for the surface layer
         """
         points = mesh.points
-        for i in range(3):
-            points[:, i] /= self.bg_atlas.resolution[i]
         cells = mesh.cells[0].data
         self.viewer.add_surface(
             (points, cells),

--- a/src/brainglobe_napari/napari_atlas_representation.py
+++ b/src/brainglobe_napari/napari_atlas_representation.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 
 from bg_atlasapi import BrainGlobeAtlas
+from meshio import Mesh
 from napari.viewer import Viewer
 
 
@@ -9,19 +10,44 @@ class NapariAtlasRepresentation:
     """Representation of a BG atlas as napari layers"""
 
     bg_atlas: BrainGlobeAtlas
+    viewer: Viewer
 
-    def add_to_viewer(self, viewer: Viewer):
-        """Adds the annotation and reference images to a viewer.
+    def add_to_viewer(self):
+        """Adds the annotation and reference images,
+        and the top-level "root" mesh, to the viewer, in that order.
 
-        The annotation image is on top, and visible,
-        while the reference image is below it and invisible.
+        The reference image's visibility is off, the others' is on.
         """
-        viewer.add_image(
+        self.viewer.add_image(
             self.bg_atlas.reference,
             name=f"{self.bg_atlas.atlas_name}_reference",
             visible=False,
         )
-        viewer.add_labels(
+        self.viewer.add_labels(
             self.bg_atlas.annotation,
             name=f"{self.bg_atlas.atlas_name}_annotation",
+        )
+
+        root_mesh = self.bg_atlas.mesh_from_structure("root")
+        self._add_mesh(root_mesh, name=f"{self.bg_atlas.atlas_name}_mesh")
+
+    def _add_mesh(self, mesh: Mesh, name: str = None):
+        """Helper function to add a mesh as a surface layer to the viewer.
+
+        mesh: the mesh to add
+        name: name for the surface layer
+        """
+        # assume local_full_name is a string
+        # structured like "allen_mouse_100um_v1.2"
+        # so we can split by '_' and 'um' to find scale.
+        scale_um = float(
+            self.bg_atlas.local_full_name.split("_")[-2].split("um")[0]
+        )
+        points = mesh.points / scale_um
+        cells = mesh.cells[0].data
+        self.viewer.add_surface(
+            (points, cells),
+            name=name,
+            opacity=0.4,
+            blending="translucent_no_depth",
         )

--- a/src/brainglobe_napari/tests/test_atlas_viewer_widget.py
+++ b/src/brainglobe_napari/tests/test_atlas_viewer_widget.py
@@ -93,14 +93,16 @@ def test_download_button_no_selection(make_atlas_viewer):
         (14, "osten_mouse_100um"),
     ],
 )
-def test_show_in_viewer_button(make_atlas_viewer, row, expected_atlas_name):
+def test_add_to_viewer_button(make_atlas_viewer, row, expected_atlas_name):
     """Check for a few low-res atlas selections that clicking the
-    "Show in Viewer" button adds a layer with the expected name."""
+    "Add to viewer" button adds the layers with their expected names."""
     viewer, atlas_viewer = make_atlas_viewer
 
     atlas_viewer.atlas_table_view.selectRow(row)
     atlas_viewer.add_to_viewer.click()
-    assert len(viewer.layers) == 2
+
+    assert len(viewer.layers) == 3
+    assert viewer.layers[2].name == f"{expected_atlas_name}_mesh"
     assert viewer.layers[1].name == f"{expected_atlas_name}_annotation"
     assert viewer.layers[0].name == f"{expected_atlas_name}_reference"
 

--- a/src/brainglobe_napari/tests/test_napari_atlas_representation.py
+++ b/src/brainglobe_napari/tests/test_napari_atlas_representation.py
@@ -1,17 +1,34 @@
+import pytest
 from bg_atlasapi import BrainGlobeAtlas
+from napari.layers import Image, Labels, Surface
 
 from brainglobe_napari.napari_atlas_representation import (
     NapariAtlasRepresentation,
 )
 
 
-def test_add_to_viewer(make_napari_viewer):
+@pytest.mark.parametrize(
+    "expected_atlas_name",
+    [
+        ("example_mouse_100um"),
+        ("allen_mouse_100um"),
+        ("osten_mouse_100um"),
+    ],
+)
+def test_add_to_viewer(make_napari_viewer, expected_atlas_name):
+    """Checks that calling add_to_viewer() adds the expected number of
+    layers, of the expected type and with the expected name.
+    """
     viewer = make_napari_viewer()
-    atlas_name = "allen_mouse_100um"
-    atlas_representation = NapariAtlasRepresentation(
-        BrainGlobeAtlas(atlas_name=atlas_name)
-    )
-    atlas_representation.add_to_viewer(viewer=viewer)
-    assert len(viewer.layers) == 2
-    assert viewer.layers[1].name == f"{atlas_name}_annotation"
-    assert viewer.layers[0].name == f"{atlas_name}_reference"
+    atlas = BrainGlobeAtlas(atlas_name=expected_atlas_name)
+    atlas_representation = NapariAtlasRepresentation(atlas, viewer)
+    atlas_representation.add_to_viewer()
+    assert len(viewer.layers) == 3
+
+    assert viewer.layers[2].name == f"{expected_atlas_name}_mesh"
+    assert viewer.layers[1].name == f"{expected_atlas_name}_annotation"
+    assert viewer.layers[0].name == f"{expected_atlas_name}_reference"
+
+    assert isinstance(viewer.layers[2], Surface)
+    assert isinstance(viewer.layers[1], Labels)
+    assert isinstance(viewer.layers[0], Image)

--- a/src/brainglobe_napari/tests/test_napari_atlas_representation.py
+++ b/src/brainglobe_napari/tests/test_napari_atlas_representation.py
@@ -1,6 +1,7 @@
 import pytest
 from bg_atlasapi import BrainGlobeAtlas
 from napari.layers import Image, Labels, Surface
+from numpy import allclose
 
 from brainglobe_napari.napari_atlas_representation import (
     NapariAtlasRepresentation,
@@ -18,6 +19,7 @@ from brainglobe_napari.napari_atlas_representation import (
 def test_add_to_viewer(make_napari_viewer, expected_atlas_name):
     """Checks that calling add_to_viewer() adds the expected number of
     layers, of the expected type and with the expected name.
+    Also checks that reference and annotation image have the same extents.
     """
     viewer = make_napari_viewer()
     atlas = BrainGlobeAtlas(atlas_name=expected_atlas_name)
@@ -25,10 +27,18 @@ def test_add_to_viewer(make_napari_viewer, expected_atlas_name):
     atlas_representation.add_to_viewer()
     assert len(viewer.layers) == 3
 
-    assert viewer.layers[2].name == f"{expected_atlas_name}_mesh"
-    assert viewer.layers[1].name == f"{expected_atlas_name}_annotation"
-    assert viewer.layers[0].name == f"{expected_atlas_name}_reference"
+    mesh, annotation, reference = (
+        viewer.layers[2],
+        viewer.layers[1],
+        viewer.layers[0],
+    )
 
-    assert isinstance(viewer.layers[2], Surface)
-    assert isinstance(viewer.layers[1], Labels)
-    assert isinstance(viewer.layers[0], Image)
+    assert mesh.name == f"{expected_atlas_name}_mesh"
+    assert annotation.name == f"{expected_atlas_name}_annotation"
+    assert reference.name == f"{expected_atlas_name}_reference"
+
+    assert isinstance(mesh, Surface)
+    assert isinstance(annotation, Labels)
+    assert isinstance(reference, Image)
+
+    assert allclose(annotation.extent.world, reference.extent.world)


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

A step on the way to including meshes as surface layers in napari.

**What does this PR do?**

Expands the `NapariAtlasRepresentation` by a surface layer containing the atlas's top-level "root" mesh.
Example screenshot with new functionality
![image](https://github.com/brainglobe/brainglobe-napari/assets/10500965/55531f87-fd30-49ae-9e7c-3e0d3c163e4e)


## References
#6 

## How has this PR been tested?

Existing tests refined and adapted to the presence of the mesh.

## Is this a breaking change?
No.

## Does this PR require an update to the documentation?

Docstrings added/modified accordingly.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
