### PR TITLE
Robustify tests

### DIFF
--- a/src/brainglobe_napari/tests/test_napari_atlas_representation.py
+++ b/src/brainglobe_napari/tests/test_napari_atlas_representation.py
@@ -30,10 +30,10 @@ def test_add_to_viewer(make_napari_viewer, expected_atlas_name, anisotropic):
         atlas.metadata["resolution"][0] *= 3
         atlas.metadata["resolution"][1] *= 2
         atlas._annotation = atlas.annotation[
-            0:len(atlas.annotation):3, 0:len(atlas.annotation[0]):2,:
+            0 : len(atlas.annotation) : 3, 0 : len(atlas.annotation[0]) : 2, :
         ]
         atlas._reference = atlas.reference[
-            0:len(atlas.reference):3, 0:len(atlas.reference[0]):2,:
+            0 : len(atlas.reference) : 3, 0 : len(atlas.reference[0]) : 2, :
         ]
 
     atlas_representation = NapariAtlasRepresentation(atlas, viewer)

--- a/src/brainglobe_napari/tests/test_napari_atlas_representation.py
+++ b/src/brainglobe_napari/tests/test_napari_atlas_representation.py
@@ -56,8 +56,10 @@ def test_add_to_viewer(make_napari_viewer, expected_atlas_name, anisotropic):
 
     assert allclose(annotation.extent.world, reference.extent.world)
 
-    # check that mesh is slightly smaller, but roughly the same size
-    # as the annotation.
+    # check that in world coordinates, the root mesh fits within
+    # a resolution step of the entire annotations image (not just
+    # the annotations themselves) but that the mesh extents are more
+    # than 75% of the annotation image extents.
     assert alltrue(
         mesh.extent.world[0] > annotation.extent.world[0] - atlas.resolution
     )

--- a/src/brainglobe_napari/tests/test_napari_atlas_representation.py
+++ b/src/brainglobe_napari/tests/test_napari_atlas_representation.py
@@ -1,7 +1,7 @@
 import pytest
 from bg_atlasapi import BrainGlobeAtlas
 from napari.layers import Image, Labels, Surface
-from numpy import allclose
+from numpy import allclose, alltrue
 
 from brainglobe_napari.napari_atlas_representation import (
     NapariAtlasRepresentation,
@@ -42,3 +42,16 @@ def test_add_to_viewer(make_napari_viewer, expected_atlas_name):
     assert isinstance(reference, Image)
 
     assert allclose(annotation.extent.world, reference.extent.world)
+
+    # check that mesh is slightly smaller, but roughly the same size
+    # as the annotation.
+    assert alltrue(
+        mesh.extent.world[0] > annotation.extent.world[0] - atlas.resolution
+    )
+    assert alltrue(
+        mesh.extent.world[1] < annotation.extent.world[1] + atlas.resolution
+    )
+    assert alltrue(
+        mesh.extent.world[1] - mesh.extent.world[0]
+        > 0.75 * (annotation.extent.world[1] - annotation.extent.world[0])
+    )

--- a/src/brainglobe_napari/tests/test_napari_atlas_representation.py
+++ b/src/brainglobe_napari/tests/test_napari_atlas_representation.py
@@ -8,6 +8,7 @@ from brainglobe_napari.napari_atlas_representation import (
 )
 
 
+@pytest.mark.parametrize("anisotropic", [True, False])
 @pytest.mark.parametrize(
     "expected_atlas_name",
     [
@@ -16,13 +17,25 @@ from brainglobe_napari.napari_atlas_representation import (
         ("osten_mouse_100um"),
     ],
 )
-def test_add_to_viewer(make_napari_viewer, expected_atlas_name):
+def test_add_to_viewer(make_napari_viewer, expected_atlas_name, anisotropic):
     """Checks that calling add_to_viewer() adds the expected number of
     layers, of the expected type and with the expected name.
     Also checks that reference and annotation image have the same extents.
     """
     viewer = make_napari_viewer()
     atlas = BrainGlobeAtlas(atlas_name=expected_atlas_name)
+
+    if anisotropic:
+        # make atlas anisotropic
+        atlas.metadata["resolution"][0] *= 3
+        atlas.metadata["resolution"][1] *= 2
+        atlas._annotation = atlas.annotation[
+            0:len(atlas.annotation):3, 0:len(atlas.annotation[0]):2,:
+        ]
+        atlas._reference = atlas.reference[
+            0:len(atlas.reference):3, 0:len(atlas.reference[0]):2,:
+        ]
+
     atlas_representation = NapariAtlasRepresentation(atlas, viewer)
     atlas_representation.add_to_viewer()
     assert len(viewer.layers) == 3


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Tests don't currently check anisotropic atlases or mesh extents in the viewer.

**What does this PR do?**
Adds tests for (artificial) anisotropic atlases and for the mesh extents matching the annotation image extents.

## References

Closes #33 
Closes #32 

## How has this PR been tested?

Local tests pass. This PR only adds new tests.

## Is this a breaking change?

Nope

## Does this PR require an update to the documentation?

Nope

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
Current pre-commit settings lead to conflict between `black` and `flake8` locally so linting may fail. To be addressed by #14 anyway