### PR TITLE
Mesh adding widget

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ install_requires =
     numpy
     magicgui
     qtpy
+    superqt
 
 python_requires = >=3.8
 include_package_data = True

--- a/src/brainglobe_napari/atlas_viewer_utils.py
+++ b/src/brainglobe_napari/atlas_viewer_utils.py
@@ -16,6 +16,7 @@ def read_atlas_metadata_from_file(atlas_name: str):
 
 
 def read_atlas_structures_from_file(atlas_name: str):
+    """Reads structure info from a '.json' in the BrainGlobe directory."""
     brainglobe_dir = Path.home() / ".brainglobe"
     with open(
         brainglobe_dir

--- a/src/brainglobe_napari/atlas_viewer_utils.py
+++ b/src/brainglobe_napari/atlas_viewer_utils.py
@@ -13,3 +13,13 @@ def read_atlas_metadata_from_file(atlas_name: str):
         / "metadata.json",
     ) as metadata_file:
         return json.loads(metadata_file.read())
+
+
+def read_atlas_structures_from_file(atlas_name: str):
+    brainglobe_dir = Path.home() / ".brainglobe"
+    with open(
+        brainglobe_dir
+        / f"{atlas_name}_v{get_local_atlas_version(atlas_name)}"
+        / "structures.json",
+    ) as metadata_file:
+        return json.loads(metadata_file.read())

--- a/src/brainglobe_napari/atlas_viewer_widget.py
+++ b/src/brainglobe_napari/atlas_viewer_widget.py
@@ -244,7 +244,7 @@ class AtlasViewerWidget(QWidget):
             )
             region_model = StructureTreeModel(structures)
             self.structure_tree_view.setModel(region_model)
-            self.structure_tree_view.hideColumn(1) # don't show structure id
+            self.structure_tree_view.hideColumn(1)  # don't show structure id
             self.structure_tree_view.setExpandsOnDoubleClick(False)
             self.structure_tree_view.setHeaderHidden(True)
             self.structure_tree_view.setWordWrap(False)

--- a/src/brainglobe_napari/atlas_viewer_widget.py
+++ b/src/brainglobe_napari/atlas_viewer_widget.py
@@ -31,6 +31,8 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
+from superqt import QCollapsible
+
 from brainglobe_napari.atlas_viewer_utils import read_atlas_metadata_from_file
 from brainglobe_napari.napari_atlas_representation import (
     NapariAtlasRepresentation,
@@ -172,7 +174,10 @@ class AtlasViewerWidget(QWidget):
         self.layout().addWidget(self.atlas_table_view)
         self.layout().addWidget(self.download_selected_atlas)
         self.layout().addWidget(self.add_to_viewer)
-        self.layout().addWidget(self.atlas_info)
+        
+        atlas_info_collapsible = QCollapsible("Atlas info")
+        atlas_info_collapsible.addWidget(self.atlas_info)
+        self.layout().addWidget(atlas_info_collapsible)
 
     def refresh_info_box(self):
         if self._selected_atlas_name in get_downloaded_atlases():

--- a/src/brainglobe_napari/atlas_viewer_widget.py
+++ b/src/brainglobe_napari/atlas_viewer_widget.py
@@ -5,7 +5,7 @@ Atlases that are exposed by the Brainglobe atlas API are
 shown in a table view using the Qt model/view framework
 [Qt Model/View framework](https://doc.qt.io/qt-6/model-view-programming.html)
 
-Users can download and add the atlas as layers to the viewer.
+Users can download and add the atlas images/structures as layers to the viewer.
 """
 from typing import TYPE_CHECKING
 
@@ -120,7 +120,7 @@ class AtlasViewerWidget(QWidget):
             """Downloads the atlas currently selected in the table view.
 
             Download only happens if it's not available locally.
-            Show's an info message otherwise.
+            Shows an info message otherwise.
             """
             if self._selected_atlas_row is not None:
                 if self._selected_atlas_name not in get_downloaded_atlases():
@@ -138,7 +138,7 @@ class AtlasViewerWidget(QWidget):
         self.add_to_viewer.setText("Add to viewer")
 
         def _on_add_to_viewer_clicked():
-            """Adds annotations as labels layer to the viewer."""
+            """Adds annotation and reference to the viewer."""
             if self._selected_atlas_row is not None:
                 if self._selected_atlas_name in get_downloaded_atlases():
                     selected_atlas = BrainGlobeAtlas(self._selected_atlas_name)
@@ -157,7 +157,7 @@ class AtlasViewerWidget(QWidget):
 
         # implement logic to update state when selection changes.
         def _on_selection_changed():
-            """Updates the internally stored info about selected row."""
+            """Updates the internal state and widgets about selected row."""
             selected_index = (
                 self.atlas_table_view.selectionModel().currentIndex()
             )
@@ -175,6 +175,7 @@ class AtlasViewerWidget(QWidget):
             _on_selection_changed
         )
 
+        # show structures in a tree view
         self.structure_tree_view = QTreeView()
         self.structure_tree_view.hide()
 
@@ -183,6 +184,8 @@ class AtlasViewerWidget(QWidget):
         self.add_structure_button.hide()
 
         def _on_add_structure_clicked():
+            """Links add structure button to selected row
+            in the structure tree view"""
             selected_index = (
                 self.structure_tree_view.selectionModel().currentIndex()
             )
@@ -218,6 +221,7 @@ class AtlasViewerWidget(QWidget):
         self.layout().addWidget(self.add_structure_button)
 
     def refresh_info_box(self):
+        """Updates the information box about the currently selected atlas."""
         if self._selected_atlas_name in get_downloaded_atlases():
             metadata = read_atlas_metadata_from_file(self._selected_atlas_name)
             metadata_as_string = ""
@@ -238,6 +242,9 @@ class AtlasViewerWidget(QWidget):
             )
 
     def refresh_structure_tree_view(self):
+        """Updates the structure tree view with the currently selected atlas.
+        The view is only visible if the selected atlas has been downloaded.
+        """
         if self._selected_atlas_name in get_downloaded_atlases():
             structures = read_atlas_structures_from_file(
                 self._selected_atlas_name

--- a/src/brainglobe_napari/atlas_viewer_widget.py
+++ b/src/brainglobe_napari/atlas_viewer_widget.py
@@ -255,7 +255,7 @@ class AtlasViewerWidget(QWidget):
             self.structure_tree_view.setExpandsOnDoubleClick(False)
             self.structure_tree_view.setHeaderHidden(True)
             self.structure_tree_view.setWordWrap(False)
-            self.structure_tree_view.expandToDepth(2)
+            self.structure_tree_view.expandToDepth(0)
             self.structure_tree_view.show()
             self.add_structure_button.show()
         else:

--- a/src/brainglobe_napari/atlas_viewer_widget.py
+++ b/src/brainglobe_napari/atlas_viewer_widget.py
@@ -167,7 +167,7 @@ class AtlasViewerWidget(QWidget):
                     self._model.index(self._selected_atlas_row, 0)
                 )
                 self.refresh_info_box()
-                self.refresh_region_view()
+                self.refresh_structure_tree_view()
             else:
                 self.atlas_info.setText("")
 
@@ -176,8 +176,11 @@ class AtlasViewerWidget(QWidget):
         )
 
         self.structure_tree_view = QTreeView()
+        self.structure_tree_view.hide()
+
         self.add_structure_button = QPushButton()
         self.add_structure_button.setText("Add structure mesh")
+        self.add_structure_button.hide()
 
         def _on_add_structure_clicked():
             selected_index = (
@@ -187,7 +190,6 @@ class AtlasViewerWidget(QWidget):
                 selected_structure_name = (
                     self.structure_tree_view.model().data(selected_index)
                 )
-                print(selected_structure_name)
                 selected_atlas = BrainGlobeAtlas(self._selected_atlas_name)
                 selected_atlas_representation = NapariAtlasRepresentation(
                     selected_atlas, self._viewer
@@ -235,15 +237,20 @@ class AtlasViewerWidget(QWidget):
                     (not downloaded yet)"
             )
 
-    def refresh_region_view(self):
+    def refresh_structure_tree_view(self):
         if self._selected_atlas_name in get_downloaded_atlases():
             structures = read_atlas_structures_from_file(
                 self._selected_atlas_name
             )
             region_model = StructureTreeModel(structures)
             self.structure_tree_view.setModel(region_model)
-            self.structure_tree_view.hideColumn(1)
+            self.structure_tree_view.hideColumn(1) # don't show structure id
             self.structure_tree_view.setExpandsOnDoubleClick(False)
             self.structure_tree_view.setHeaderHidden(True)
             self.structure_tree_view.setWordWrap(False)
             self.structure_tree_view.expandToDepth(2)
+            self.structure_tree_view.show()
+            self.add_structure_button.show()
+        else:
+            self.structure_tree_view.hide()
+            self.add_structure_button.hide()

--- a/src/brainglobe_napari/napari_atlas_representation.py
+++ b/src/brainglobe_napari/napari_atlas_representation.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 
+import numpy as np
 from bg_atlasapi import BrainGlobeAtlas
 from meshio import Mesh
 from napari.viewer import Viewer
@@ -37,11 +38,14 @@ class NapariAtlasRepresentation:
 
     def add_structure_to_viewer(self, structure_name: str):
         mesh = self.bg_atlas.mesh_from_structure(structure_name)
+        color = self.bg_atlas.structures[structure_name]["rgb_triplet"]
         self._add_mesh(
-            mesh, name=f"{self.bg_atlas.atlas_name}_{structure_name}_mesh"
+            mesh,
+            name=f"{self.bg_atlas.atlas_name}_{structure_name}_mesh",
+            color=color,
         )
 
-    def _add_mesh(self, mesh: Mesh, name: str = None):
+    def _add_mesh(self, mesh: Mesh, name: str = None, color=None):
         """Helper function to add a mesh as a surface layer to the viewer.
 
         mesh: the mesh to add
@@ -49,9 +53,13 @@ class NapariAtlasRepresentation:
         """
         points = mesh.points
         cells = mesh.cells[0].data
-        self.viewer.add_surface(
-            (points, cells),
+        viewer_kwargs = dict(
             name=name,
             opacity=self.mesh_opacity,
             blending=self.mesh_blending,
         )
+        if color:
+            viewer_kwargs["vertex_colors"] = np.repeat(
+                [color], len(points), axis=0
+            )
+        self.viewer.add_surface((points, cells), **viewer_kwargs)

--- a/src/brainglobe_napari/napari_atlas_representation.py
+++ b/src/brainglobe_napari/napari_atlas_representation.py
@@ -35,6 +35,12 @@ class NapariAtlasRepresentation:
         root_mesh = self.bg_atlas.mesh_from_structure("root")
         self._add_mesh(root_mesh, name=f"{self.bg_atlas.atlas_name}_mesh")
 
+    def add_structure_to_viewer(self, structure_name: str):
+        mesh = self.bg_atlas.mesh_from_structure(structure_name)
+        self._add_mesh(
+            mesh, name=f"{self.bg_atlas.atlas_name}_{structure_name}_mesh"
+        )
+
     def _add_mesh(self, mesh: Mesh, name: str = None):
         """Helper function to add a mesh as a surface layer to the viewer.
 

--- a/src/brainglobe_napari/napari_atlas_representation.py
+++ b/src/brainglobe_napari/napari_atlas_representation.py
@@ -16,10 +16,9 @@ class NapariAtlasRepresentation:
     mesh_blending: str = "translucent_no_depth"
 
     def add_to_viewer(self):
-        """Adds the annotation and reference images,
-        and the top-level "root" mesh, to the viewer, in that order.
+        """Adds the reference and annotation images to the viewer.
 
-        The reference image's visibility is off, the others' is on.
+        The reference image's visibility is off, the annotation's is on.
         """
         self.viewer.add_image(
             self.bg_atlas.reference,
@@ -34,6 +33,10 @@ class NapariAtlasRepresentation:
         )
 
     def add_structure_to_viewer(self, structure_name: str):
+        """Adds the mesh of a structure to the viewer
+
+        structure_name: the id or acronym of the structure.
+        """
         mesh = self.bg_atlas.mesh_from_structure(structure_name)
         color = self.bg_atlas.structures[structure_name]["rgb_triplet"]
         self._add_mesh(

--- a/src/brainglobe_napari/napari_atlas_representation.py
+++ b/src/brainglobe_napari/napari_atlas_representation.py
@@ -33,9 +33,6 @@ class NapariAtlasRepresentation:
             name=f"{self.bg_atlas.atlas_name}_annotation",
         )
 
-        root_mesh = self.bg_atlas.mesh_from_structure("root")
-        self._add_mesh(root_mesh, name=f"{self.bg_atlas.atlas_name}_mesh")
-
     def add_structure_to_viewer(self, structure_name: str):
         mesh = self.bg_atlas.mesh_from_structure(structure_name)
         color = self.bg_atlas.structures[structure_name]["rgb_triplet"]

--- a/src/brainglobe_napari/structure_tree_model.py
+++ b/src/brainglobe_napari/structure_tree_model.py
@@ -1,0 +1,138 @@
+from typing import List
+
+from bg_atlasapi.structure_tree_util import get_structures_tree
+from qtpy.QtCore import QAbstractItemModel, QModelIndex, Qt
+
+
+class StructureTreeItem:
+    def __init__(self, data, parent=None):
+        self.parent_item = parent
+        self.item_data = data
+        self.child_items = []
+
+    def appendChild(self, item):
+        self.child_items.append(item)
+
+    def child(self, row):
+        return self.child_items[row]
+
+    def childCount(self):
+        return len(self.child_items)
+
+    def columnCount(self):
+        return len(self.item_data)
+
+    def data(self, column):
+        try:
+            return self.item_data[column]
+        except IndexError:
+            return None
+
+    def parent(self):
+        return self.parent_item
+
+    def row(self):
+        if self.parent_item:
+            return self.parent_item.child_items.index(self)
+        return 0
+
+
+class StructureTreeModel(QAbstractItemModel):
+    def __init__(self, data: List, parent=None):
+        super().__init__()
+        self.root_item = StructureTreeItem(data=("Atlas regions", "-1"))
+        self.setupModelData(data, self.root_item)
+
+    def setupModelData(self, regions: List, root: StructureTreeItem = None):
+        tree = get_structures_tree(regions)
+        region_id_dict = {}
+        for region in regions:
+            region_id_dict[region["id"]] = region
+
+        inserted_items = {}
+        for n_id in tree.expand_tree():  # sorts nodes by default,
+            # so parents will always be already in the QAbstractItemModel
+            # before their children
+            node = tree.get_node(n_id)
+            acronym = region_id_dict[node.identifier]["acronym"]
+            if len(region_id_dict[node.identifier]["structure_id_path"]) == 1:
+                parent_item = root
+            else:
+                parent_id = tree.parent(node.identifier).identifier
+                parent_item = inserted_items[parent_id]
+
+            item = StructureTreeItem(
+                data=(acronym, node.identifier), parent=parent_item
+            )
+            parent_item.appendChild(item)
+            inserted_items[node.identifier] = item
+
+    def data(self, index: QModelIndex, role=Qt.DisplayRole):
+        if not index.isValid():
+            return None
+
+        if role != Qt.DisplayRole:
+            return None
+
+        item = index.internalPointer()
+
+        return item.data(index.column())
+
+    def flags(self, index):
+        """Make read-only, but selectable"""
+        if not index.isValid():
+            return Qt.NoItemFlags
+
+        return Qt.ItemIsEnabled | Qt.ItemIsSelectable
+
+    def rowCount(self, parent: StructureTreeItem):
+        if parent.column() > 0:
+            return 0
+
+        if not parent.isValid():
+            parent_item = self.root_item
+        else:
+            parent_item = parent.internalPointer()
+
+        return parent_item.childCount()
+
+    def columnCount(self, parent: StructureTreeItem):
+        if parent.isValid():
+            return parent.internalPointer().columnCount()
+        else:
+            return self.root_item.columnCount()
+
+    def headerData(
+        self, section: int, orientation: Qt.Orientation, role: Qt.ItemDataRole
+    ):
+        if orientation == Qt.Horizontal and role == Qt.DisplayRole:
+            return self.root_item.data(section)
+
+        return None
+
+    def parent(self, index: QModelIndex):
+        if not index.isValid():
+            return QModelIndex()
+
+        child_item = index.internalPointer()
+        parent_item = child_item.parent()
+
+        if parent_item == self.root_item:
+            return QModelIndex()
+
+        return self.createIndex(parent_item.row(), 0, parent_item)
+
+    def index(self, row, column, parent):
+        if not self.hasIndex(row, column, parent):
+            return QModelIndex()
+
+        if not parent.isValid():
+            parent_item = self.root_item
+        else:
+            parent_item = parent.internalPointer()
+
+        child_item = parent_item.child(row)
+        if child_item:
+            return self.createIndex(row, column, child_item)
+        else:
+            return QModelIndex()

--- a/src/brainglobe_napari/structure_tree_model.py
+++ b/src/brainglobe_napari/structure_tree_model.py
@@ -78,13 +78,6 @@ class StructureTreeModel(QAbstractItemModel):
 
         return item.data(index.column())
 
-    def flags(self, index):
-        """Make read-only, but selectable"""
-        if not index.isValid():
-            return Qt.NoItemFlags
-
-        return Qt.ItemIsEnabled | Qt.ItemIsSelectable
-
     def rowCount(self, parent: StructureTreeItem):
         if parent.column() > 0:
             return 0
@@ -102,14 +95,6 @@ class StructureTreeModel(QAbstractItemModel):
         else:
             return self.root_item.columnCount()
 
-    def headerData(
-        self, section: int, orientation: Qt.Orientation, role: Qt.ItemDataRole
-    ):
-        if orientation == Qt.Horizontal and role == Qt.DisplayRole:
-            return self.root_item.data(section)
-
-        return None
-
     def parent(self, index: QModelIndex):
         if not index.isValid():
             return QModelIndex()
@@ -122,7 +107,7 @@ class StructureTreeModel(QAbstractItemModel):
 
         return self.createIndex(parent_item.row(), 0, parent_item)
 
-    def index(self, row, column, parent):
+    def index(self, row, column, parent=QModelIndex()):
         if not self.hasIndex(row, column, parent):
             return QModelIndex()
 

--- a/src/brainglobe_napari/tests/test_atlas_viewer_widget.py
+++ b/src/brainglobe_napari/tests/test_atlas_viewer_widget.py
@@ -142,3 +142,20 @@ def test_add_structure_button(make_atlas_viewer, mocker):
     # First sub-item in tree view expected to be "VS"
     atlas_viewer.add_structure_button.click()
     add_structure_to_viewer_mock.assert_called_once_with("VS")
+
+
+@pytest.mark.parametrize(
+    "row, expected_visibility",
+    [
+        (4, True),  # allen_mouse_100um is part of downloaded test data
+        (5, False),  # mpin_fish_1um is not part of download test data
+    ],
+)
+def test_add_structure_visibility(make_atlas_viewer, row, expected_visibility):
+    """Checks that the structure tree view and add structure buttons
+    are visible iff atlas has previously been downloaded."""
+    _, atlas_viewer = make_atlas_viewer
+    atlas_viewer.show()  # show tree view ancestor for sensible check
+    atlas_viewer.atlas_table_view.selectRow(row)
+    assert atlas_viewer.structure_tree_view.isVisible() == expected_visibility
+    assert atlas_viewer.add_structure_button.isVisible() == expected_visibility

--- a/src/brainglobe_napari/tests/test_atlas_viewer_widget.py
+++ b/src/brainglobe_napari/tests/test_atlas_viewer_widget.py
@@ -101,8 +101,7 @@ def test_add_to_viewer_button(make_atlas_viewer, row, expected_atlas_name):
     atlas_viewer.atlas_table_view.selectRow(row)
     atlas_viewer.add_to_viewer.click()
 
-    assert len(viewer.layers) == 3
-    assert viewer.layers[2].name == f"{expected_atlas_name}_mesh"
+    assert len(viewer.layers) == 2
     assert viewer.layers[1].name == f"{expected_atlas_name}_annotation"
     assert viewer.layers[0].name == f"{expected_atlas_name}_reference"
 

--- a/src/brainglobe_napari/tests/test_atlas_viewer_widget.py
+++ b/src/brainglobe_napari/tests/test_atlas_viewer_widget.py
@@ -113,3 +113,32 @@ def test_show_in_viewer_button_no_selection(make_atlas_viewer):
 
     atlas_viewer.add_to_viewer.click()
     assert len(viewer.layers) == 0
+
+
+def test_add_structure_button(make_atlas_viewer, mocker):
+    """Checks that clicking the add_structure_button with
+    the allen_mouse_100um atlas and its VS submesh selected
+    in the widget views calls the NapariAtlasRepresentation
+    function in the expected way.
+    """
+    _, atlas_viewer = make_atlas_viewer
+    add_structure_to_viewer_mock = mocker.patch(
+        "brainglobe_napari.atlas_viewer_widget"
+        ".NapariAtlasRepresentation.add_structure_to_viewer"
+    )
+    atlas_viewer.atlas_table_view.selectRow(4)  # allen_mouse_100um is in row 4
+
+    # find and select first sub-item of root mesh in structure tree view
+    root_index = atlas_viewer.structure_tree_view.rootIndex()
+    root_mesh_index = atlas_viewer.structure_tree_view.model().index(
+        0, 0, root_index
+    )
+    vs_mesh_index = atlas_viewer.structure_tree_view.model().index(
+        0, 0, root_mesh_index
+    )
+    assert vs_mesh_index.isValid()
+    atlas_viewer.structure_tree_view.setCurrentIndex(vs_mesh_index)
+
+    # First sub-item in tree view expected to be "VS"
+    atlas_viewer.add_structure_button.click()
+    add_structure_to_viewer_mock.assert_called_once_with("VS")

--- a/src/brainglobe_napari/tests/test_napari_atlas_representation.py
+++ b/src/brainglobe_napari/tests/test_napari_atlas_representation.py
@@ -38,35 +38,16 @@ def test_add_to_viewer(make_napari_viewer, expected_atlas_name, anisotropic):
 
     atlas_representation = NapariAtlasRepresentation(atlas, viewer)
     atlas_representation.add_to_viewer()
-    assert len(viewer.layers) == 3
+    assert len(viewer.layers) == 2
 
-    mesh, annotation, reference = (
-        viewer.layers[2],
+    annotation, reference = (
         viewer.layers[1],
         viewer.layers[0],
     )
-
-    assert mesh.name == f"{expected_atlas_name}_mesh"
     assert annotation.name == f"{expected_atlas_name}_annotation"
     assert reference.name == f"{expected_atlas_name}_reference"
 
-    assert isinstance(mesh, Surface)
     assert isinstance(annotation, Labels)
     assert isinstance(reference, Image)
 
     assert allclose(annotation.extent.world, reference.extent.world)
-
-    # check that in world coordinates, the root mesh fits within
-    # a resolution step of the entire annotations image (not just
-    # the annotations themselves) but that the mesh extents are more
-    # than 75% of the annotation image extents.
-    assert alltrue(
-        mesh.extent.world[0] > annotation.extent.world[0] - atlas.resolution
-    )
-    assert alltrue(
-        mesh.extent.world[1] < annotation.extent.world[1] + atlas.resolution
-    )
-    assert alltrue(
-        mesh.extent.world[1] - mesh.extent.world[0]
-        > 0.75 * (annotation.extent.world[1] - annotation.extent.world[0])
-    )


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
There is currently no way to add structure meshes to napari.

**What does this PR do?**
Adds a button and a selectable tree view to the napari plugin, which allows adding of individual structure meshes to napari.

## References

Gets us 2/3 of the way to closing #6 

## How has this PR been tested?

Tests added for both widgets and napari representation.

## Is this a breaking change?

Not really. Root mesh is added via that structure-adding functionality tnow.

## Does this PR require an update to the documentation?

Docstrings added. But would be nice to add some things to a user guide at some point?

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
