### PR TITLE
add to viewer button > double-click

### DIFF
--- a/src/brainglobe_napari/atlas_download_dialog.py
+++ b/src/brainglobe_napari/atlas_download_dialog.py
@@ -1,0 +1,40 @@
+from bg_atlasapi.list_atlases import get_all_atlases_lastversions
+from qtpy.QtWidgets import (
+    QDialog,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QVBoxLayout,
+)
+
+
+class AtlasDownloadDialog(QDialog):
+    """A modal dialog to ask users to confirm they'd like to download
+    the selected atlas, and warn them that it may be slow.
+    """
+
+    def __init__(self, atlas_name):
+        if atlas_name in get_all_atlases_lastversions().keys():
+            super().__init__()
+
+            self.setWindowTitle(f"Download {atlas_name} Atlas")
+            self.setModal(True)
+
+            self.label = QLabel("Are you sure?\n(It may take a while)")
+            self.ok_button = QPushButton("Yes")
+            self.ok_button.clicked.connect(self.accept)
+            self.cancel_button = QPushButton("No")
+            self.cancel_button.clicked.connect(self.reject)
+
+            button_layout = QHBoxLayout()
+            button_layout.addWidget(self.ok_button)
+            button_layout.addWidget(self.cancel_button)
+
+            layout = QVBoxLayout()
+            layout.addWidget(self.label)
+            layout.addLayout(button_layout)
+            self.setLayout(layout)
+        else:
+            raise ValueError(
+                "Download Dialog constructor called with invalid atlas name."
+            )

--- a/src/brainglobe_napari/atlas_viewer_widget.py
+++ b/src/brainglobe_napari/atlas_viewer_widget.py
@@ -133,11 +133,7 @@ class AtlasViewerWidget(QWidget):
             _on_download_selected_atlas_clicked
         )
 
-        # set up add button
-        self.add_to_viewer = QPushButton()
-        self.add_to_viewer.setText("Add to viewer")
-
-        def _on_add_to_viewer_clicked():
+        def on_row_double_clicked():
             """Adds annotation and reference to the viewer."""
             if self._selected_atlas_row is not None:
                 if self._selected_atlas_name in get_downloaded_atlases():
@@ -149,7 +145,7 @@ class AtlasViewerWidget(QWidget):
                 else:
                     show_info("Please download this atlas first.")
 
-        self.add_to_viewer.clicked.connect(_on_add_to_viewer_clicked)
+        self.atlas_table_view.doubleClicked.connect(on_row_double_clicked)
 
         # set up atlas info display
         self.atlas_info = QTextEdit(self)
@@ -211,7 +207,6 @@ class AtlasViewerWidget(QWidget):
         # add sub-widgets to top-level widget
         self.layout().addWidget(self.atlas_table_view)
         self.layout().addWidget(self.download_selected_atlas)
-        self.layout().addWidget(self.add_to_viewer)
 
         atlas_info_collapsible = QCollapsible("Atlas info")
         atlas_info_collapsible.addWidget(self.atlas_info)

--- a/src/brainglobe_napari/atlas_viewer_widget.py
+++ b/src/brainglobe_napari/atlas_viewer_widget.py
@@ -205,11 +205,10 @@ class AtlasViewerWidget(QWidget):
             for key, value in metadata.items():
                 metadata_as_string += f"{key}:\t{value}\n"
 
-            tooltip_text = (
-                f"{atlas_name} (available locally)\n {metadata_as_string}"
-            )
+            tooltip_text = f"{atlas_name} (double-click to add to viewer)\
+            \n{metadata_as_string}"
         else:
-            tooltip_text = f"{atlas_name} (not downloaded yet)"
+            tooltip_text = f"{atlas_name} (double-click to download)"
         return tooltip_text
 
     def refresh_structure_tree_view(self):

--- a/src/brainglobe_napari/atlas_viewer_widget.py
+++ b/src/brainglobe_napari/atlas_viewer_widget.py
@@ -193,8 +193,10 @@ class AtlasViewerWidget(QWidget):
 
             tooltip_text = f"{atlas_name} (double-click to add to viewer)\
             \n{metadata_as_string}"
-        else:
+        elif atlas_name in get_all_atlases_lastversions().keys():
             tooltip_text = f"{atlas_name} (double-click to download)"
+        else:
+            raise ValueError("Tooltip text called with invalid atlas name.")
         return tooltip_text
 
     def refresh_structure_tree_view(self):

--- a/src/brainglobe_napari/atlas_viewer_widget.py
+++ b/src/brainglobe_napari/atlas_viewer_widget.py
@@ -133,7 +133,7 @@ class AtlasViewerWidget(QWidget):
             _on_download_selected_atlas_clicked
         )
 
-        def on_row_double_clicked():
+        def on_atlas_row_double_clicked():
             """Adds annotation and reference to the viewer."""
             if self._selected_atlas_row is not None:
                 if self._selected_atlas_name in get_downloaded_atlases():
@@ -145,7 +145,9 @@ class AtlasViewerWidget(QWidget):
                 else:
                     show_info("Please download this atlas first.")
 
-        self.atlas_table_view.doubleClicked.connect(on_row_double_clicked)
+        self.atlas_table_view.doubleClicked.connect(
+            on_atlas_row_double_clicked
+        )
 
         # set up atlas info display
         self.atlas_info = QTextEdit(self)
@@ -175,11 +177,7 @@ class AtlasViewerWidget(QWidget):
         self.structure_tree_view = QTreeView()
         self.structure_tree_view.hide()
 
-        self.add_structure_button = QPushButton()
-        self.add_structure_button.setText("Add structure mesh")
-        self.add_structure_button.hide()
-
-        def _on_add_structure_clicked():
+        def on_structure_row_double_clicked():
             """Links add structure button to selected row
             in the structure tree view"""
             selected_index = (
@@ -196,13 +194,10 @@ class AtlasViewerWidget(QWidget):
                 selected_atlas_representation.add_structure_to_viewer(
                     selected_structure_name
                 )
-            else:
-                show_info(
-                    "No structure selected. Select a structure first \
-                    to add it to napari."
-                )
 
-        self.add_structure_button.clicked.connect(_on_add_structure_clicked)
+        self.structure_tree_view.doubleClicked.connect(
+            on_structure_row_double_clicked
+        )
 
         # add sub-widgets to top-level widget
         self.layout().addWidget(self.atlas_table_view)
@@ -213,7 +208,6 @@ class AtlasViewerWidget(QWidget):
         self.layout().addWidget(atlas_info_collapsible)
 
         self.layout().addWidget(self.structure_tree_view)
-        self.layout().addWidget(self.add_structure_button)
 
     def refresh_info_box(self):
         """Updates the information box about the currently selected atlas."""
@@ -252,7 +246,5 @@ class AtlasViewerWidget(QWidget):
             self.structure_tree_view.setWordWrap(False)
             self.structure_tree_view.expandToDepth(0)
             self.structure_tree_view.show()
-            self.add_structure_button.show()
         else:
             self.structure_tree_view.hide()
-            self.add_structure_button.hide()

--- a/src/brainglobe_napari/tests/conftest.py
+++ b/src/brainglobe_napari/tests/conftest.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import pytest
 from bg_atlasapi import config
+from qtpy.QtCore import Qt
 
 
 @pytest.fixture(autouse=True)
@@ -46,3 +47,25 @@ def mock_brainglobe_user_folders(monkeypatch):
             }
         }
         monkeypatch.setattr(config, "TEMPLATE_CONF_DICT", mock_default_dirs)
+
+
+@pytest.fixture
+def double_click_on_view(qtbot):
+    def inner_double_click_on_view(view, index):
+        viewport_index = view.visualRect(index).center()
+
+        # weirdly, to correctly emulate a double-click
+        # you need to click first. Also, note that the view
+        # needs to be interacted with via its viewport
+        qtbot.mouseClick(
+            view.viewport(),
+            Qt.MouseButton.LeftButton,
+            pos=viewport_index,
+        )
+        qtbot.mouseDClick(
+            view.viewport(),
+            Qt.MouseButton.LeftButton,
+            pos=viewport_index,
+        )
+
+    return inner_double_click_on_view

--- a/src/brainglobe_napari/tests/test_atlas_viewer_widget.py
+++ b/src/brainglobe_napari/tests/test_atlas_viewer_widget.py
@@ -128,13 +128,13 @@ def test_double_click_on_atlas_view(
     assert viewer.layers[0].name == f"{expected_atlas_name}_reference"
 
 
-def test_add_structure_button(make_atlas_viewer, mocker):
+def test_structure_row_double_clicked(make_atlas_viewer, mocker, qtbot):
     """Checks that clicking the add_structure_button with
     the allen_mouse_100um atlas and its VS submesh selected
     in the widget views calls the NapariAtlasRepresentation
     function in the expected way.
     """
-    _, atlas_viewer = make_atlas_viewer
+    viewer, atlas_viewer = make_atlas_viewer
     add_structure_to_viewer_mock = mocker.patch(
         "brainglobe_napari.atlas_viewer_widget"
         ".NapariAtlasRepresentation.add_structure_to_viewer"
@@ -153,7 +153,24 @@ def test_add_structure_button(make_atlas_viewer, mocker):
     atlas_viewer.structure_tree_view.setCurrentIndex(vs_mesh_index)
 
     # First sub-item in tree view expected to be "VS"
-    atlas_viewer.add_structure_button.click()
+    viewport_index = atlas_viewer.structure_tree_view.visualRect(
+        vs_mesh_index
+    ).center()
+
+    # weirdly, to correctly emulate a double-click
+    # you need to click first. Also, note that the view
+    # needs to be interacted with via its viewport
+    qtbot.mouseClick(
+        atlas_viewer.structure_tree_view.viewport(),
+        Qt.MouseButton.LeftButton,
+        pos=viewport_index,
+    )
+    qtbot.mouseDClick(
+        atlas_viewer.structure_tree_view.viewport(),
+        Qt.MouseButton.LeftButton,
+        pos=viewport_index,
+    )
+
     add_structure_to_viewer_mock.assert_called_once_with("VS")
 
 
@@ -171,4 +188,3 @@ def test_add_structure_visibility(make_atlas_viewer, row, expected_visibility):
     atlas_viewer.show()  # show tree view ancestor for sensible check
     atlas_viewer.atlas_table_view.selectRow(row)
     assert atlas_viewer.structure_tree_view.isVisible() == expected_visibility
-    assert atlas_viewer.add_structure_button.isVisible() == expected_visibility

--- a/src/brainglobe_napari/tests/test_download_dialog.py
+++ b/src/brainglobe_napari/tests/test_download_dialog.py
@@ -1,0 +1,20 @@
+import pytest
+
+from brainglobe_napari.atlas_download_dialog import AtlasDownloadDialog
+
+
+def test_download_dialog(qtbot):
+    """Check download dialog constructor and buttons connections"""
+    dialog = AtlasDownloadDialog("example_mouse_100um")
+    with qtbot.waitSignal(dialog.accepted):
+        dialog.ok_button.click()
+
+    with qtbot.waitSignal(dialog.rejected):
+        dialog.cancel_button.click()
+
+
+def test_download_dialog_raises():
+    """Check download dialog constructor errors on invalid input"""
+    with pytest.raises(ValueError) as e:
+        _ = AtlasDownloadDialog("wrong_atlas_name")
+        assert "invalid atlas name" in e

--- a/src/brainglobe_napari/tests/test_napari_atlas_representation.py
+++ b/src/brainglobe_napari/tests/test_napari_atlas_representation.py
@@ -1,7 +1,7 @@
 import pytest
 from bg_atlasapi import BrainGlobeAtlas
 from napari.layers import Image, Labels
-from numpy import allclose, alltrue
+from numpy import all, allclose
 
 from brainglobe_napari.napari_atlas_representation import (
     NapariAtlasRepresentation,
@@ -70,20 +70,21 @@ def test_add_structure_to_viewer(make_napari_viewer, expected_atlas_name):
     assert len(viewer.layers) == 1
     mesh = viewer.layers[0]
 
-    atlas_representation.add_to_viewer()  # add other images so we can check mesh extents
+    # add other images so we can check mesh extents
+    atlas_representation.add_to_viewer()
     annotation = viewer.layers[1]
 
     # check that in world coordinates, the root mesh fits within
     # a resolution step of the entire annotations image (not just
     # the annotations themselves) but that the mesh extents are more
     # than 75% of the annotation image extents.
-    assert alltrue(
+    assert all(
         mesh.extent.world[0] > annotation.extent.world[0] - atlas.resolution
     )
-    assert alltrue(
+    assert all(
         mesh.extent.world[1] < annotation.extent.world[1] + atlas.resolution
     )
-    assert alltrue(
+    assert all(
         mesh.extent.world[1] - mesh.extent.world[0]
         > 0.75 * (annotation.extent.world[1] - annotation.extent.world[0])
     )


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
Our widgets are multiplying and there's no space for them any more

**What does this PR do?**
- moves the atlas info to be a tooltip on the atlas table view
- removes the download and add to viewer button, which are replaced by double-clicking rows
- to guard users from a too rash download, a confirmation dialog is displayed

To account for this, the atlas widget tests were refactored heavily. This refactor includes the adding of a new fixture in `conftest.py` to simplify emulating a user doubleclicking on a view. 

## References
Closes #45 

## How has this PR been tested?

Existing tests were refactored and some new ones added. Automated tests pass, and I've tested manually too.

## Is this a breaking change?
yes, the UI changes completely (but no underlying fu

## Does this PR require an update to the documentation?
Nope

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [n/a] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
