### PR TITLE
Correctly render the default mesh colour in napari

### DIFF
--- a/src/brainglobe_napari/napari_atlas_representation.py
+++ b/src/brainglobe_napari/napari_atlas_representation.py
@@ -50,6 +50,7 @@ class NapariAtlasRepresentation:
 
         mesh: the mesh to add
         name: name for the surface layer
+        color: RGB values (0-255) as a list to colour mesh with
         """
         points = mesh.points
         cells = mesh.cells[0].data
@@ -59,6 +60,7 @@ class NapariAtlasRepresentation:
             blending=self.mesh_blending,
         )
         if color:
+            # convert RGB (0-255) to rgb (0.0-1.0)
             viewer_kwargs["vertex_colors"] = np.repeat(
                 [[float(c) / 255 for c in color]], len(points), axis=0
             )

--- a/src/brainglobe_napari/napari_atlas_representation.py
+++ b/src/brainglobe_napari/napari_atlas_representation.py
@@ -60,6 +60,6 @@ class NapariAtlasRepresentation:
         )
         if color:
             viewer_kwargs["vertex_colors"] = np.repeat(
-                [color], len(points), axis=0
+                [[float(c) / 255 for c in color]], len(points), axis=0
             )
         self.viewer.add_surface((points, cells), **viewer_kwargs)

--- a/src/brainglobe_napari/tests/test_napari_atlas_representation.py
+++ b/src/brainglobe_napari/tests/test_napari_atlas_representation.py
@@ -62,6 +62,8 @@ def test_add_to_viewer(make_napari_viewer, expected_atlas_name, anisotropic):
     ],
 )
 def test_add_structure_to_viewer(make_napari_viewer, expected_atlas_name):
+    """Check that the root mesh extents __roughly__ match the size
+    of the annnotations image."""
     viewer = make_napari_viewer()
     atlas = BrainGlobeAtlas(atlas_name=expected_atlas_name)
 
@@ -70,7 +72,8 @@ def test_add_structure_to_viewer(make_napari_viewer, expected_atlas_name):
     assert len(viewer.layers) == 1
     mesh = viewer.layers[0]
 
-    atlas_representation.add_to_viewer()  # add other images so we can check mesh extents
+    # add other images so we can check mesh extents
+    atlas_representation.add_to_viewer()
     annotation = viewer.layers[1]
 
     # check that in world coordinates, the root mesh fits within
@@ -87,3 +90,20 @@ def test_add_structure_to_viewer(make_napari_viewer, expected_atlas_name):
         mesh.extent.world[1] - mesh.extent.world[0]
         > 0.75 * (annotation.extent.world[1] - annotation.extent.world[0])
     )
+
+
+def test_structure_color(make_napari_viewer):
+    """Checks that the default colour of a structure
+    is propagated correctly to the corresponding napari layer
+    """
+    viewer = make_napari_viewer()
+    atlas = BrainGlobeAtlas(atlas_name="allen_mouse_100um")
+
+    atlas_representation = NapariAtlasRepresentation(atlas, viewer)
+    atlas_representation.add_structure_to_viewer("CTXsp")
+
+    expected_RGB = atlas.structures["CTXsp"]["rgb_triplet"]
+    actual_rgb = viewer.layers[0].vertex_colors[0]
+
+    for a, e in zip(actual_rgb, expected_RGB):
+        assert a * 255 == e


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Most meshes are coloured white when you add them to napari

**What does this PR do?**
Performs the right colourspace conversion from the structures's RGB to napari rgb, so the mesh default colours are displayed correctly.

## References
Closes #50 

## How has this PR been tested?

Manually:
![image](https://github.com/brainglobe/brainglobe-napari/assets/10500965/e8fc7a05-054d-4eaf-b511-1af089ba2a1b)

Also, added a simple unit test.

## Is this a breaking change?

Nope

## Does this PR require an update to the documentation?
Docstring of `_add_mesh` has been updated.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
